### PR TITLE
Feat/devin support custom api tag name

### DIFF
--- a/packages/vitdoc-runtime/index.html
+++ b/packages/vitdoc-runtime/index.html
@@ -5,7 +5,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="{{icon || '//vitdocjs.github.io/logo.svg'}}"
+      href="{{favicon || '//vitdocjs.github.io/logo.svg'}}"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:type" content="website" />

--- a/packages/vitdoc-runtime/index.html
+++ b/packages/vitdoc-runtime/index.html
@@ -5,7 +5,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="//vitdocjs.github.io/logo.svg"
+      href="{{icon || '//vitdocjs.github.io/logo.svg'}}"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:type" content="website" />

--- a/packages/vitdoc-ui/src/components/API/index.tsx
+++ b/packages/vitdoc-ui/src/components/API/index.tsx
@@ -1,4 +1,3 @@
-import { useRequest } from "ahooks";
 import { useAtom } from "jotai";
 import React, { useEffect, useRef } from "react";
 import { propertiesStore } from "../../store";

--- a/packages/vitdoc-ui/src/components/dumi-components/index.tsx
+++ b/packages/vitdoc-ui/src/components/dumi-components/index.tsx
@@ -66,8 +66,8 @@ export function DumiDemo(props: {
         ...props.style,
         ...(previewerProps.background
           ? {
-              background: previewerProps.background,
-            }
+            background: previewerProps.background,
+          }
           : {}),
       }}
     />

--- a/packages/vitdoc-ui/src/hooks/loaders.ts
+++ b/packages/vitdoc-ui/src/hooks/loaders.ts
@@ -17,7 +17,7 @@ export function useRoute() {
   return { route };
 }
 
-export class ModuleLoadError extends Error {}
+export class ModuleLoadError extends Error { }
 
 const loadedMap = {};
 
@@ -42,7 +42,7 @@ export function useLoadModule<T>(
               actions.mutate(dealWithResult(newModule));
             });
           })
-          .catch(() => {});
+          .catch(() => { });
 
         return dealWithResult(res);
       });
@@ -91,14 +91,16 @@ export function useRouteMap(): any {
     });
     return result;
   };
+
   return useAsyncImport(`/route-map.json`, ({ default: items }) => ({
     ...items,
     flattenRoutes: flatRouteMap(items.tree),
   }))?.data;
 }
 
-export function useComponentInfo(): any {
-  return useAsyncImport(`/package.json`, ({ default: packageInfo }) => {
+
+export function useComponentInfo(packageJsonPath?: string): any {
+  return useAsyncImport(packageJsonPath || `/package.json`, ({ default: packageInfo }) => {
     const packageName = packageInfo.name;
     const packageVersion = packageInfo.version;
     const registry = (

--- a/packages/vitdoc-ui/src/theme.tsx
+++ b/packages/vitdoc-ui/src/theme.tsx
@@ -5,6 +5,7 @@ import { DumiDemo, DumiDemoGrid, DumiPage } from "./components/dumi-components";
 import SourceCode from "./components/highlight";
 import { Table } from "./components/table";
 
+
 export {
   Table,
   CardBlock,

--- a/packages/vitdoc/src/core/config.ts
+++ b/packages/vitdoc/src/core/config.ts
@@ -6,6 +6,7 @@ import { flatten } from "lodash-es";
 import fs from "fs";
 
 import { resolveConfig as esBuildResolveConfig } from "esbuild-resolve-config";
+import { isMonorepo } from "../utils/is-monorepo";
 
 export function getUserConfig(): UserConfig {
   const defaultConfig = {
@@ -28,6 +29,7 @@ export function getUserConfig(): UserConfig {
 
   return config;
 }
+
 
 /**
  * Resolve the config into a usable format.
@@ -54,6 +56,8 @@ export async function resolveConfig(
   ];
 
   const pluginContainer = createPluginContainer(workerUserPlugins);
+
+  workerConfig.isMonorepo = isMonorepo(process.cwd());
 
   workerConfig = await pluginContainer("config", [workerConfig], {
     iterate: mergeConfig as any,

--- a/packages/vitdoc/src/core/config.ts
+++ b/packages/vitdoc/src/core/config.ts
@@ -24,7 +24,7 @@ export function getUserConfig(): UserConfig {
         ? fs.readFileSync(config.htmlAppend, "utf8")
         : "";
     }
-  } catch (e) {}
+  } catch (e) { }
 
   return config;
 }

--- a/packages/vitdoc/src/core/types.ts
+++ b/packages/vitdoc/src/core/types.ts
@@ -61,6 +61,7 @@ export type PluginOption =
 
 export interface ResolvedConfig extends Required<UserConfig> {
   plugins: Plugin[];
+  isMonorepo: boolean;
 }
 
 export const defineConfig = (config: UserConfig) => config;

--- a/packages/vitdoc/src/plugins/components-template/index.ts
+++ b/packages/vitdoc/src/plugins/components-template/index.ts
@@ -142,6 +142,7 @@ const componentsTemplate = async (vitdoc: VitdocInstance) => {
     template: templatePath,
     htmlAppend: externalHtml,
     logo,
+    icon,
     docDirs,
     isMonorepo,
   } = vitdoc.resolvedConfig;
@@ -277,6 +278,7 @@ const componentsTemplate = async (vitdoc: VitdocInstance) => {
           name,
           description,
           logo,
+          icon,
           moduleMaps: [...mdFileMap]
             .filter(Boolean)
             .map(

--- a/packages/vitdoc/src/plugins/components-template/index.ts
+++ b/packages/vitdoc/src/plugins/components-template/index.ts
@@ -142,7 +142,7 @@ const componentsTemplate = async (vitdoc: VitdocInstance) => {
     template: templatePath,
     htmlAppend: externalHtml,
     logo,
-    icon,
+    favicon,
     docDirs,
     isMonorepo,
   } = vitdoc.resolvedConfig;
@@ -278,7 +278,7 @@ const componentsTemplate = async (vitdoc: VitdocInstance) => {
           name,
           description,
           logo,
-          icon,
+          favicon,
           moduleMaps: [...mdFileMap]
             .filter(Boolean)
             .map(

--- a/packages/vitdoc/src/plugins/components-template/index.ts
+++ b/packages/vitdoc/src/plugins/components-template/index.ts
@@ -71,6 +71,8 @@ export const getRoutes = async (docDirs: string[], isMonorepo = false) => {
     });
 
     const groupPath = readmePath.match(/^(\/.*?)(\/.*?)(?=\/)/)
+
+    // creating a package.json path in the monorepo
     const packageJsonPath = isMonorepo && groupPath && path.join(groupPath.slice(1, 3).join(''), "package.json");
 
     const order = metaOrder ?? index + 0.1;

--- a/packages/vitdoc/src/plugins/components-template/index.ts
+++ b/packages/vitdoc/src/plugins/components-template/index.ts
@@ -135,6 +135,7 @@ const componentsTemplate = async (vitdoc: VitdocInstance) => {
     htmlAppend: externalHtml,
     logo,
     docDirs,
+    customApiTag,
   } = vitdoc.resolvedConfig;
 
   const entry = await resolve("@vitdoc/runtime/index.html", {

--- a/packages/vitdoc/src/plugins/markdown-jsx/index.ts
+++ b/packages/vitdoc/src/plugins/markdown-jsx/index.ts
@@ -76,6 +76,7 @@ const mdjsx = (vitdoc: VitdocInstance) => {
         return transformResult;
       }
 
+
       if (!/\.md$/.test(id)) {
         return;
       }

--- a/packages/vitdoc/src/plugins/markdown-jsx/index.ts
+++ b/packages/vitdoc/src/plugins/markdown-jsx/index.ts
@@ -15,7 +15,7 @@ export const getDemoId = (id) =>
   id.match(mdProxyRE)?.[1]?.match(/(.+?)(\.\w+)?$/)?.[1];
 
 const mdjsx = (vitdoc: VitdocInstance) => {
-  const { template } = vitdoc.resolvedConfig;
+  const { template, customApiTag } = vitdoc.resolvedConfig;
 
   let markdownMap: Record<string, IDemoData> = {};
   let transformPromises: Record<string, Promise<any>> = {};
@@ -95,6 +95,7 @@ const mdjsx = (vitdoc: VitdocInstance) => {
         emitDemo(info) {
           markdownMap[info.id] = info;
         },
+        customApiTag
       });
 
       return transformPromises[id];

--- a/packages/vitdoc/src/plugins/markdown-jsx/index.ts
+++ b/packages/vitdoc/src/plugins/markdown-jsx/index.ts
@@ -15,7 +15,7 @@ export const getDemoId = (id) =>
   id.match(mdProxyRE)?.[1]?.match(/(.+?)(\.\w+)?$/)?.[1];
 
 const mdjsx = (vitdoc: VitdocInstance) => {
-  const { template, customApiTag } = vitdoc.resolvedConfig;
+  const { template } = vitdoc.resolvedConfig;
 
   let markdownMap: Record<string, IDemoData> = {};
   let transformPromises: Record<string, Promise<any>> = {};
@@ -95,7 +95,6 @@ const mdjsx = (vitdoc: VitdocInstance) => {
         emitDemo(info) {
           markdownMap[info.id] = info;
         },
-        customApiTag
       });
 
       return transformPromises[id];

--- a/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
+++ b/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
@@ -22,21 +22,17 @@ export async function transformMarkdown(
 ) {
   let content = fs.readFileSync(id, "utf-8");
 
-  // replace API Component to custom Component
+  // replace to <API /> follow customApiTag
   if (customApiTag) {
     const { srcAttributeName, tagName } = customApiTag
 
     const tagNameRegex = new RegExp(`<(/)?${tagName}(.*?)>`, 'g')
     const attributeNameRegex = new RegExp(`${srcAttributeName}=`, 'g')
 
-
     content = content.replace(tagNameRegex, "<$1API$2>");
 
-
-    // replace attribute name path to src
     content = content.replace(attributeNameRegex, "src=");
   }
-
 
   content = appendTypes(content, () => resolveMainComponent(id, cwd));
 

--- a/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
+++ b/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
@@ -38,11 +38,7 @@ export async function transformMarkdown(
   }
 
 
-
-
   content = appendTypes(content, () => resolveMainComponent(id, cwd));
-
-
 
   const res = (await markdownTransformer(content, {
     cwd: process.cwd(),
@@ -133,6 +129,7 @@ export default MarkdownContent;
 
     return transformWithEsbuild(code, `${id}.jsx`);
   }
+
 
   return emit.call(
     this,

--- a/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
+++ b/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
@@ -18,21 +18,10 @@ const markdownTransformer = jiti(import.meta.url, {
 
 export async function transformMarkdown(
   this: any,
-  { id, cwd, emitDemo, builtins, alias, customApiTag }
+  { id, cwd, emitDemo, builtins, alias }
 ) {
   let content = fs.readFileSync(id, "utf-8");
 
-  // replace to <API /> follow customApiTag
-  if (customApiTag) {
-    const { srcAttributeName, tagName } = customApiTag
-
-    const tagNameRegex = new RegExp(`<(/)?${tagName}(.*?)>`, 'g')
-    const attributeNameRegex = new RegExp(`${srcAttributeName}=`, 'g')
-
-    content = content.replace(tagNameRegex, "<$1API$2>");
-
-    content = content.replace(attributeNameRegex, "src=");
-  }
 
   content = appendTypes(content, () => resolveMainComponent(id, cwd));
 
@@ -125,6 +114,8 @@ export default MarkdownContent;
 
     return transformWithEsbuild(code, `${id}.jsx`);
   }
+
+
 
 
   return emit.call(

--- a/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
+++ b/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
@@ -18,20 +18,25 @@ const markdownTransformer = jiti(import.meta.url, {
 
 export async function transformMarkdown(
   this: any,
-  { id, cwd, emitDemo, builtins, alias }
+  { id, cwd, emitDemo, builtins, alias, customApiTag }
 ) {
   let content = fs.readFileSync(id, "utf-8");
 
+  // replace API Component to custom Component
+  if (customApiTag) {
+    const { srcAttributeName, tagName } = customApiTag
 
-  // replace ReactDocgenProps to API
-  content = content.replace(/<ReactDocgenProps/g, "<API");
-  content = content.replace(/ReactDocgenProps>/g, "API>");
+    const tagNameRegex = new RegExp(`<(/)?${tagName}(.*?)>`, 'g')
+    const attributeNameRegex = new RegExp(`${srcAttributeName}=`, 'g')
 
 
-  // replace attribute name path to src
-  content = content.replace(/path=/g, "src=");
+    content = content.replace(tagNameRegex, "<$1API$2>");
 
-  console.log('content', content)
+
+    // replace attribute name path to src
+    content = content.replace(attributeNameRegex, "src=");
+  }
+
 
 
 

--- a/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
+++ b/packages/vitdoc/src/plugins/markdown-jsx/markdown/transform.ts
@@ -22,7 +22,22 @@ export async function transformMarkdown(
 ) {
   let content = fs.readFileSync(id, "utf-8");
 
+
+  // replace ReactDocgenProps to API
+  content = content.replace(/<ReactDocgenProps/g, "<API");
+  content = content.replace(/ReactDocgenProps>/g, "API>");
+
+
+  // replace attribute name path to src
+  content = content.replace(/path=/g, "src=");
+
+  console.log('content', content)
+
+
+
   content = appendTypes(content, () => resolveMainComponent(id, cwd));
+
+
 
   const res = (await markdownTransformer(content, {
     cwd: process.cwd(),
@@ -101,8 +116,8 @@ const $$contentTexts = ${JSON.stringify(texts)};
 export const meta$ = ${stringifyEval(meta)};
 
 ${styles
-  .map((style) => `import '${id}?markdown-proxy&id=${style.id}.scss';`)
-  .join("\n")}
+        .map((style) => `import '${id}?markdown-proxy&id=${style.id}.scss';`)
+        .join("\n")}
 
 function MarkdownContent() {
   return ${ret.content};

--- a/packages/vitdoc/src/plugins/type-file/index.ts
+++ b/packages/vitdoc/src/plugins/type-file/index.ts
@@ -75,12 +75,17 @@ const TypeFile = ({
         requestedUrlMap[file.replace(matchReg, "")] = true;
 
         const mainUrl = file.replace(matchReg, "");
-        const fileName = normalizePath(mainUrl.replace(/^\//, ""));
+        const fileName = normalizePath(
+          mainUrl.replace(/^\//, "")
+            .replace(new RegExp('/?' + process.cwd().replace(/^\//, '') + '/?'), "")
+        );
 
         const componentDoc: any = await getComponentDocs(fileName);
+
         if (isBuild && componentDoc) {
           metas.push({ metas: keyBy(componentDoc, "exportName"), fileName });
         }
+
 
         if (!Object.keys(componentDoc).length) {
           return `export default {};`;

--- a/packages/vitdoc/src/types.ts
+++ b/packages/vitdoc/src/types.ts
@@ -71,17 +71,4 @@ export type ConfigType = {
    * @default ["docs", "src"]
    */
   docDirs?: string[];
-
-  /**
-   * API Component Tag
-   */
-  customApiTag?: {
-    tagName?: string;
-    srcAttributeName?: string;
-  }
-
-  /**
-   * is monorepo project
-   */
-  isMonorepo?: boolean
 };

--- a/packages/vitdoc/src/types.ts
+++ b/packages/vitdoc/src/types.ts
@@ -66,4 +66,17 @@ export type ConfigType = {
    * @default ["docs", "src"]
    */
   docDirs?: string[];
+
+  /**
+   * API Component Tag
+   */
+  customApiTag?: {
+    tagName?: string;
+    srcAttributeName?: string;
+  }
+
+  /**
+   * is monorepo project
+   */
+  isMonorepo?: boolean
 };

--- a/packages/vitdoc/src/types.ts
+++ b/packages/vitdoc/src/types.ts
@@ -41,9 +41,9 @@ export type ConfigType = {
   logo?: string;
 
   /**
-   * Page Icon
+   * Page Favicon
    */
-  icon?: string;
+  favicon?: string;
 
   /**
    * Expand the html

--- a/packages/vitdoc/src/types.ts
+++ b/packages/vitdoc/src/types.ts
@@ -41,6 +41,11 @@ export type ConfigType = {
   logo?: string;
 
   /**
+   * Page Icon
+   */
+  icon?: string;
+
+  /**
    * Expand the html
    */
   htmlAppend?: string;

--- a/packages/vitdoc/src/utils/is-monorepo.ts
+++ b/packages/vitdoc/src/utils/is-monorepo.ts
@@ -1,0 +1,51 @@
+import * as fs from "fs";
+import * as path from 'path'
+
+// 检查不同 monorepo 工具的配置文件
+const monorepoConfigFiles = {
+  lerna: 'lerna.json',
+  yarnWorkspaces: 'package.json', // 包含 workspaces 字段
+  pnpmWorkspaces: 'pnpm-workspace.yaml',
+};
+
+
+// 检查指定路径下是否有对应的配置文件
+function hasConfigFile(rootPath: string, configFile: string) {
+  return fs.existsSync(path.join(rootPath, configFile));
+}
+
+// 检查 package.json 是否具有工作区配置
+function hasYarnWorkspacesConfig(rootPath: string) {
+  const packageJsonPath = path.join(rootPath, 'package.json');
+
+  if (fs.existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    return packageJson.workspaces !== undefined;
+  }
+
+  return false;
+}
+
+// 检查是否为 monorepo
+function checkForMonorepo(rootPath) {
+  // 检查 monorepo 特定的配置文件
+  for (const tool in monorepoConfigFiles) {
+    const configFile = monorepoConfigFiles[tool];
+
+    if (hasConfigFile(rootPath, configFile)) {
+      if (tool === 'yarnWorkspaces') {
+        if (hasYarnWorkspacesConfig(rootPath)) {
+          return true;
+        }
+      } else {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function isMonorepo(path: string) {
+  return checkForMonorepo(path);
+}

--- a/templates/common/src/pages/readme-pane/index.tsx
+++ b/templates/common/src/pages/readme-pane/index.tsx
@@ -39,7 +39,7 @@ export default function ReadmePane() {
 
   const currentRoute = flattenRoutes.find(({ path }) => path === route);
 
-  const compInfo = useComponentInfo(currentRoute?.packageJsonPath);
+  const compInfo = currentRoute.packageJsonInfo || useComponentInfo();
 
   return (
     <div id="public-component-show-container">

--- a/templates/common/src/pages/readme-pane/index.tsx
+++ b/templates/common/src/pages/readme-pane/index.tsx
@@ -6,12 +6,13 @@ import {
   LinkCopy,
   PropertyPane,
   Store,
-  useComponentInfo,
   useMarkdown,
   useRoute,
   useRouteMap,
+  useComponentInfo,
 } from "@vitdoc/ui";
 import { Outlet } from "virtual:vitdoc-router";
+
 
 import "./index.scss";
 
@@ -34,11 +35,11 @@ export default function ReadmePane() {
     });
   });
 
-  const compInfo = useComponentInfo();
-
-  const { flattenRoutes = [] } = useRouteMap() || {};
+  const { flattenRoutes = [], } = useRouteMap() || {};
 
   const currentRoute = flattenRoutes.find(({ path }) => path === route);
+
+  const compInfo = useComponentInfo(currentRoute?.packageJsonPath);
 
   return (
     <div id="public-component-show-container">

--- a/templates/mobile/src/pages/readme-pane/index.tsx
+++ b/templates/mobile/src/pages/readme-pane/index.tsx
@@ -33,11 +33,13 @@ export default function ReadmePane() {
     });
   });
 
-  const compInfo = useComponentInfo();
 
   const { flattenRoutes = [] } = useRouteMap() || {};
 
   const currentRoute = flattenRoutes.find(({ path }) => path === route);
+
+  const compInfo = useComponentInfo(currentRoute?.packageJsonPath);
+
 
   return (
     <div id="public-component-show-container">

--- a/templates/mobile/src/pages/readme-pane/index.tsx
+++ b/templates/mobile/src/pages/readme-pane/index.tsx
@@ -38,7 +38,7 @@ export default function ReadmePane() {
 
   const currentRoute = flattenRoutes.find(({ path }) => path === route);
 
-  const compInfo = useComponentInfo(currentRoute?.packageJsonPath);
+  const compInfo = currentRoute.packageJsonInfo || useComponentInfo();
 
 
   return (


### PR DESCRIPTION
## 改动点

- 增加 favicon 用于 favicon 配置
- 增加 isMonorepo 内置逻辑判断
- 适配格式 xxx-xxx 的目录名，如 abc-def，之前检查到 abc 就停止了，改成了识别 abc-def 为目录名
- 修改 @vitdoc/theme-default 、@vitdoc/theme-mobile 下 packageInfo 的引用
- monorepo 仓库下 routemap.json 新增 packageJsonInfo 用于多包信息的保存
<img width="462" alt="image" src="https://github.com/vitdocjs/vitdoc/assets/22369504/58c7eb09-c6c6-4813-954e-1e6d51a0368b">
