### PR TITLE
Add "Open with Codeanywhere" badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
 </p>
 
 <p align="center">
-  <a href="https://stackblitz.com/edit/vitdoc?file=src/README.md"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt=""></a>
+  <a href="https://stackblitz.com/edit/vitdoc?file=src/README.md"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt=""></a> 
+  </p>
+  <p align="center">
+  <a href="https://app.codeanywhere.com/#https://github.com/vitdocjs/vitdoc"><img src="https://codeanywhere.com/img/open-in-codeanywhere-btn.svg" alt=""></a>
 </p>
-
 
 Based on [Vite](https://github.com/vitejs/vite), use `markdown` to write React component documentation, and automatically extract component interface definitions.
 

--- a/packages/vitdoc-ui/README.md
+++ b/packages/vitdoc-ui/README.md
@@ -14,7 +14,9 @@
 <p align="center">
   <a href="https://stackblitz.com/edit/vitdoc?file=src/README.md"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt=""></a>
 </p>
-
+ <p align="center">
+  <a href="https://app.codeanywhere.com/#https://github.com/vitdocjs/vitdoc"><img src="https://codeanywhere.com/img/open-in-codeanywhere-btn.svg" alt=""></a>
+</p>
 
 Based on [Vite](https://github.com/vitejs/vite), use `markdown` to write React component documentation, and automatically extract component interface definitions.
 

--- a/packages/vitdoc/README.md
+++ b/packages/vitdoc/README.md
@@ -14,7 +14,9 @@
 <p align="center">
   <a href="https://stackblitz.com/edit/vitdoc?file=src/README.md"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt=""></a>
 </p>
-
+<p align="center">
+  <a href="https://app.codeanywhere.com/#https://github.com/vitdocjs/vitdoc"><img src="https://codeanywhere.com/img/open-in-codeanywhere-btn.svg" alt=""></a>
+</p>
 
 Based on [Vite](https://github.com/vitejs/vite), use `markdown` to write React component documentation, and automatically extract component interface definitions.
 


### PR DESCRIPTION
Hey hey,

I’ve added a shiny new 'Open with Codeanywhere' badge to our README.md! 🚀

This badge makes it super easy for anyone to spin up a pre-configured dev environment—whether in the cloud or locally. It’s all set up to ensure everyone has access to the same tools, no fuss, no setup headaches. Perfect for contributors or anyone jumping into the codebase for the first time.

Let me know what you think or if there’s anything we can tweak!